### PR TITLE
Fix prompt action buttons by decoding stored prompt data

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -736,8 +736,8 @@
                     tabPanel.innerHTML = `
                         <p class="text-gray-800 dark:text-gray-200 break-words mb-4">${finalPrompt}</p>
                         <div class="flex space-x-2">
-                            <button class="copy-btn flex-1 bg-gray-200 dark:bg-gray-600 hover:bg-gray-300 dark:hover:bg-gray-500 text-sm font-medium py-2 px-3 rounded-md transition-colors" data-prompt="${CSS.escape(finalPrompt)}">Copy</button>
-                            <button class="save-btn flex-1 bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300 hover:bg-indigo-200 dark:hover:bg-indigo-900 text-sm font-medium py-2 px-3 rounded-md transition-colors" data-prompt="${CSS.escape(finalPrompt)}">Save to Library</button>
+                            <button class="copy-btn flex-1 bg-gray-200 dark:bg-gray-600 hover:bg-gray-300 dark:hover:bg-gray-500 text-sm font-medium py-2 px-3 rounded-md transition-colors" data-prompt="${encodeURIComponent(finalPrompt)}">Copy</button>
+                            <button class="save-btn flex-1 bg-indigo-100 dark:bg-indigo-900/50 text-indigo-700 dark:text-indigo-300 hover:bg-indigo-200 dark:hover:bg-indigo-900 text-sm font-medium py-2 px-3 rounded-md transition-colors" data-prompt="${encodeURIComponent(finalPrompt)}">Save to Library</button>
                         </div>
                     `;
                     tabsNav.appendChild(tabButton);
@@ -784,15 +784,27 @@
             tabsPanels.addEventListener('click', e => {
                 const target = e.target.closest('button');
                 if (!target) return;
-                const unescapedPrompt = CSS.unescape(target.dataset.prompt);
+
+                const encodedPrompt = target.dataset.prompt;
+                if (!encodedPrompt) return;
+
+                let decodedPrompt;
+                try {
+                    decodedPrompt = decodeURIComponent(encodedPrompt);
+                } catch (error) {
+                    console.error('Failed to decode prompt', error);
+                    showToast('Unable to process the selected prompt.');
+                    return;
+                }
+
                 if (target.classList.contains('copy-btn')) {
-                    navigator.clipboard.writeText(unescapedPrompt).then(() => {
+                    navigator.clipboard.writeText(decodedPrompt).then(() => {
                         target.textContent = 'Copied!';
                         setTimeout(() => { target.textContent = 'Copy' }, 2000);
                     });
                 }
                 if (target.classList.contains('save-btn')) {
-                    savePrompt(unescapedPrompt);
+                    savePrompt(decodedPrompt);
                     target.textContent = 'Saved!';
                     target.disabled = true;
                 }


### PR DESCRIPTION
## Summary
- replace the use of CSS.escape for storing prompts with encodeURIComponent so the generated HTML attributes stay valid
- decode the stored prompt text when handling copy/save actions and surface an error toast if decoding fails
- ensure the prompt text is available to the clipboard and prompt library buttons without throwing runtime errors

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68cbd8d311348329a5c343b0fabb32dc